### PR TITLE
Additions of wrappers and performance improvement

### DIFF
--- a/@opSpot/cgls.m
+++ b/@opSpot/cgls.m
@@ -6,7 +6,7 @@ function varargout = cgls(A,b,varargin)
 %
 %   This routine is simply a wrapper to a custom CGLS routine, and the
 %   argument list variations described in CGLS documentation are also
-%   allowed here.  The usage is identical to the default version, except
+%   allowed here. The usage is identical to the default version, except
 %   that the first argument must be a Spot operator.
 
 fun = @(x, opt) afun(A, x, opt);

--- a/@opSpot/cgls.m
+++ b/@opSpot/cgls.m
@@ -1,0 +1,34 @@
+function varargout = cgls(A,b,varargin)
+%CGLS Conjugate Gradients Least Squares
+%
+%   X = CGLS(A,B) attempts to solve the linear system A*X=B via the CGLS
+%   method.
+%
+%   This routine is simply a wrapper to a custom CGLS routine, and the
+%   argument list variations described in CGLS documentation are also
+%   allowed here.  The usage is identical to the default version, except
+%   that the first argument must be a Spot operator.
+
+fun = @(x, opt) afun(A, x, opt);
+
+if nargout == 0
+    cgls(fun, b, varargin{:});
+elseif nargout <= 4
+    varargout = cell(1,nargout);
+    [varargout{:}] = cgls(fun,b,varargin{:});
+else
+    error('Too many output arguments.');
+end
+
+end
+
+
+function y = afun(A, x, opt)
+
+if opt == 1
+    y = A*x;
+elseif opt == 2
+    y = A'*x;
+end
+
+end

--- a/@opSpot/lsmr.m
+++ b/@opSpot/lsmr.m
@@ -1,0 +1,33 @@
+function varargout = lsmr(A,b,varargin)
+%LSMR Iterative solver for least-squares problems.
+%
+%   X = LSMR(A,B) solves the system of linear equations A*X = B.
+%
+%   This routine is simply a wrapper to a custom LSMR routine, and the
+%   argument list variations described in LSMR documentation are also
+%   allowed here. The usage is identical to the default version, except
+%   that the first argument must be a Spot operator.
+
+fun = @(x, opt) afun(A, x, opt);
+
+if nargout == 0
+    lsmr(fun, b, varargin{:});
+elseif nargout <= 8
+    varargout = cell(1,nargout);
+    [varargout{:}] = lsmr(fun,b,varargin{:});
+else
+    error('Too many output arguments');
+end
+
+end
+
+
+function y = afun(A, x, opt)
+
+if opt == 1
+    y = A*x;
+elseif opt == 2
+    y = A'*x;
+end
+
+end

--- a/@opSpot/opSpot.m
+++ b/@opSpot/opSpot.m
@@ -90,11 +90,14 @@ classdef opSpot
                    else
                       y = zeros(op.n, q, class(x));
                    end
-                end
                 
-                for i=1:q
-                    y(:,i) = op.multiply(x(:,i), mode);
+                   for i=1:q
+                       y(:,i) = op.multiply(x(:,i), mode);
+                   end
+                else
+                    y = op.multiply(x, mode);
                 end
+
             end
         end
         

--- a/@opSpot/sum.m
+++ b/@opSpot/sum.m
@@ -1,0 +1,28 @@
+function s = sum(A,dim)
+%SUM Sums rows or columns of a Spot operator.
+%
+%   S = sum(A), for an M-by-N Spot operator A, S is a row vector with the
+%   sum of elements of each column.
+%
+%   S = SUM(A,DIM) sums along the dimension DIM. 
+%   Note that DIM must be 1 or 2.
+
+if nargin == 0
+    error('Not enough input arguments');
+    
+elseif nargin > 2
+    error('Too many input arguments');
+    
+elseif nargin > 1 && ~isempty(dim)
+    if ~(dim == 1 || dim == 2)
+        error('Dimension argument must be 1 or 2');
+    end
+else
+    dim = 1;
+end
+
+if dim == 1
+    s = (A'*ones(A.m,1))';
+else
+    s = A*ones(A.n,1);
+end

--- a/tests/test_iterative.m
+++ b/tests/test_iterative.m
@@ -57,6 +57,38 @@ function test_iterative_lsqr
    
 end
 
+function test_iterative_lsmr
+
+   n  = 100; on = ones(n,1); A = spdiags([-2*on 4*on -on],-1:1,n,n);
+   b  = sum(A,2); tol = 1e-8; maxit = 15; lambda = 0;
+   [x1,flag1,relres1,iter1] = lsmr(A,b,lambda,tol,tol,[],maxit);
+   
+   Aop = opFunction(n,n,@(x,mode)afun_diff(x,n,mode));
+   [x2,flag2,relres2,iter2] = lsmr(Aop,b,lambda,tol,tol,[],maxit);
+      
+   assertElementsAlmostEqual(x1,x2)
+   assertElementsAlmostEqual(flag1,flag2)
+   assertElementsAlmostEqual(relres1,relres2)
+   assertElementsAlmostEqual(iter1,iter2)
+   
+end
+
+function test_iterative_cgls
+
+   n  = 100; on = ones(n,1); A = spdiags([-2*on 4*on -on],-1:1,n,n);
+   b  = sum(A,2); tol = 1e-8; maxit = 15; shift = 0;
+   [x1,flag1,relres1,iter1] = cgls(A,b,shift,tol,maxit);
+   
+   Aop = opFunction(n,n,@(x,mode)afun_diff(x,n,mode));
+   [x2,flag2,relres2,iter2] = cgls(Aop,b,shift,tol,maxit);
+      
+   assertElementsAlmostEqual(x1,x2)
+   assertElementsAlmostEqual(flag1,flag2)
+   assertElementsAlmostEqual(relres1,relres2)
+   assertElementsAlmostEqual(iter1,iter2)
+   
+end
+
 function test_iterative_qmr
 
    n  = 100; on = ones(n,1); A = spdiags([-2*on 4*on -on],-1:1,n,n);

--- a/tests/test_sum.m
+++ b/tests/test_sum.m
@@ -1,0 +1,19 @@
+ function test_suite = test_sum
+ %test_sum Unit tests for sum
+ initTestSuite;
+ end
+ 
+ function test_sum_explicit
+         
+     Aex = rand(100);
+     Aop = opMatrix(Aex);
+     
+     colSum_ex = sum(Aex,1);
+     colSum_op = sum(Aop,1);
+     assertElementsAlmostEqual(colSum_ex,colSum_op);
+     
+     rowSum_ex = sum(Aex,1);
+     rowSum_op = sum(Aop,1);
+     assertElementsAlmostEqual(rowSum_ex,rowSum_op);
+     
+end


### PR DESCRIPTION
I've added some wrappers for least squares solvers I regularly use (LSMR and CGLS), these can be downloaded from the standford website. CGLS does not adhere to the usual input argument order CGLS(A,b, ...), therefore I've changed this in my own implementation. If the license on CGLS allows, I could include this version in the spot toolbox?

Using the profiler of matlab, I noticed quiet a large overhead in opSpot.applyMultiply. I've included a fix for that.
